### PR TITLE
Use file name directly instead of Framework notation

### DIFF
--- a/Sources/MDFInternationalization.h
+++ b/Sources/MDFInternationalization.h
@@ -16,9 +16,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import <MDFInternationalization/MDFRTL.h>
-#import <MDFInternationalization/UIImage+MaterialRTL.h>
-#import <MDFInternationalization/UIView+MaterialRTL.h>
+#import "MDFRTL.h"
+#import "UIImage+MaterialRTL.h"
+#import "UIView+MaterialRTL.h"
 
 //! Project version number for MDFInternationalization.
 FOUNDATION_EXPORT double MDFInternationalizationVersionNumber;


### PR DESCRIPTION
Using file_name directly instead of MDFInternationalization/file_name allows simpler include as third party dependency.