### PR TITLE
Remove framework-style headers from the umbrella header.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -30,7 +30,6 @@ fix_bazel_imports() {
   fi
   
   rewrite_source() {
-    find "${stashed_dir}${tests_dir_prefix}Sources" -type f -name '*.h' -exec sed -i '' -E "$1" {} + || true
     find "${stashed_dir}${tests_dir_prefix}Tests" -type f -name '*.h' -exec sed -i '' -E "$1" {} + || true
     find "${stashed_dir}${tests_dir_prefix}Tests" -type f -name '*.m' -exec sed -i '' -E "$1" {} + || true
   }

--- a/Sources/MDFInternationalization.h
+++ b/Sources/MDFInternationalization.h
@@ -16,9 +16,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import <MDFInternationalization/MDFRTL.h>
-#import <MDFInternationalization/UIImage+MaterialRTL.h>
-#import <MDFInternationalization/UIView+MaterialRTL.h>
+#import "MDFRTL.h"
+#import "UIImage+MaterialRTL.h"
+#import "UIView+MaterialRTL.h"
 
 //! Project version number for MDFInternationalization.
 FOUNDATION_EXPORT double MDFInternationalizationVersionNumber;


### PR DESCRIPTION
This will allow downstream dependencies to build the library with bazel without having to modify the source.