### PR TITLE
[Bazel] Fix BUILD file SDK dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,11 @@ strict_warnings_objc_library(
     hdrs = glob([
         "Sources/*.h",
     ]),
+    sdk_frameworks = [
+        "UIKit",
+        "CoreGraphics",
+        "CoreImage",
+    ],
     defines = ["IS_BAZEL_BUILD"],
     enable_modules = 1,
     includes = ["Sources"],

--- a/Sources/UIImage+MaterialRTL.m
+++ b/Sources/UIImage+MaterialRTL.m
@@ -16,6 +16,7 @@
 
 #import "UIImage+MaterialRTL.h"
 
+#import <CoreGraphics/CoreGraphics.h>
 #import <CoreImage/CoreImage.h>
 
 /** Returns the horizontally flipped version of the given UIImageOrientation. */

--- a/Sources/UIImage+MaterialRTL.m
+++ b/Sources/UIImage+MaterialRTL.m
@@ -16,6 +16,8 @@
 
 #import "UIImage+MaterialRTL.h"
 
+#import <CoreImage/CoreImage.h>
+
 /** Returns the horizontally flipped version of the given UIImageOrientation. */
 static UIImageOrientation MDFRTLMirroredOrientation(UIImageOrientation sourceOrientation) {
   switch (sourceOrientation) {


### PR DESCRIPTION
UIImage processing was missing some of its SDK dependencies.