### PR TITLE
Update bazel workspace to latest versions.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -22,31 +22,6 @@ set -x
 
 KOKORO_RUNNER_VERSION="v3.*"
 
-fix_bazel_imports() {
-  if [ -z "$KOKORO_BUILD_NUMBER" ]; then
-    tests_dir_prefix=""
-  else
-    tests_dir_prefix="github/repo/"
-  fi
-  
-  rewrite_source() {
-    find "${stashed_dir}${tests_dir_prefix}Tests" -type f -name '*.h' -exec sed -i '' -E "$1" {} + || true
-    find "${stashed_dir}${tests_dir_prefix}Tests" -type f -name '*.m' -exec sed -i '' -E "$1" {} + || true
-  }
-
-  # CocoaPods requires that public headers of dependent pods be implemented using framework import
-  # notation, while bazel requires that dependency headers be imported with quoted notation.
-  stashed_dir=""
-  rewrite_source "s/import <MDFInternationalization\/(.+)\.h>/import \"\1.h\"/"
-  stashed_dir="$(pwd)/"
-  reset_imports() {
-    # Undoes our source changes from above.
-    rewrite_source "s/import \"MDF(.+).h\"/import <MDFInternationalization\/MDF\1.h>/"
-    rewrite_source "s/import \"(.+)\+MaterialRTL\.h\"/import <MDFInternationalization\/\1+MaterialRTL.h>/"
-  }
-  trap reset_imports EXIT
-}
-
 if [ ! -d .kokoro-ios-runner ]; then
   git clone https://github.com/material-foundation/kokoro-ios-runner.git .kokoro-ios-runner
 fi
@@ -56,8 +31,6 @@ git fetch > /dev/null
 TAG=$(git tag --sort=v:refname -l "$KOKORO_RUNNER_VERSION" | tail -n1)
 git checkout "$TAG" > /dev/null
 popd
-
-fix_bazel_imports
 
 ./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
 

--- a/.kokoro
+++ b/.kokoro
@@ -34,7 +34,7 @@ popd
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
-  use_bazel.sh 0.20
+  use_bazel.sh 0.20.0
   bazel version
 fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -32,7 +32,11 @@ TAG=$(git tag --sort=v:refname -l "$KOKORO_RUNNER_VERSION" | tail -n1)
 git checkout "$TAG" > /dev/null
 popd
 
-bazel version
+if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+  bazel version
+  use_bazel.sh latest	
+  bazel version
+fi
 
 ./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
 

--- a/.kokoro
+++ b/.kokoro
@@ -32,6 +32,8 @@ TAG=$(git tag --sort=v:refname -l "$KOKORO_RUNNER_VERSION" | tail -n1)
 git checkout "$TAG" > /dev/null
 popd
 
+bazel version
+
 ./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
 
 echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -34,7 +34,7 @@ popd
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
-  use_bazel.sh latest	
+  use_bazel.sh 0.20
   bazel version
 fi
 

--- a/BUILD
+++ b/BUILD
@@ -21,6 +21,13 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+DEFAULT_IOS_RUNNER_TARGETS = [
+    "//components/testing/runners:IPHONE_5_IN_8_1",
+    "//components/testing/runners:IPAD_PRO_12_9_IN_9_3",
+    "//components/testing/runners:IPHONE_7_PLUS_IN_10_3",
+    "//components/testing/runners:IPHONE_X_IN_11_0",
+]
+
 strict_warnings_objc_library(
     name = "MDFInternationalization",
     srcs = glob([
@@ -62,12 +69,13 @@ objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "UnitTests",
     deps = [
-      ":UnitTestsLib",
+        ":UnitTestsLib",
     ],
     minimum_os_version = "8.0",
-    timeout = "short",
+    runners = DEFAULT_IOS_RUNNER_TARGETS,
     visibility = ["//visibility:private"],
+    size = "small",
 )

--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
-load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load(":apple_framework_relative_headers.bzl", "apple_framework_relative_headers")
 

--- a/BUILD
+++ b/BUILD
@@ -21,13 +21,6 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-DEFAULT_IOS_RUNNER_TARGETS = [
-    "//components/testing/runners:IPHONE_5_IN_8_1",
-    "//components/testing/runners:IPAD_PRO_12_9_IN_9_3",
-    "//components/testing/runners:IPHONE_7_PLUS_IN_10_3",
-    "//components/testing/runners:IPHONE_X_IN_11_0",
-]
-
 strict_warnings_objc_library(
     name = "MDFInternationalization",
     srcs = glob([
@@ -69,13 +62,12 @@ objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
+ios_unit_test(
     name = "UnitTests",
     deps = [
-        ":UnitTestsLib",
+      ":UnitTestsLib",
     ],
     minimum_os_version = "8.0",
-    runners = DEFAULT_IOS_RUNNER_TARGETS,
+    timeout = "short",
     visibility = ["//visibility:private"],
-    size = "small",
 )

--- a/BUILD
+++ b/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 load(":apple_framework_relative_headers.bzl", "apple_framework_relative_headers")
 
 licenses(["notice"])  # Apache 2.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,31 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-#git_repository(
-#    name = "io_bazel",
-#    remote = "https://github.com/bazelbuild/bazel.git",
-#    tag = "0.14.0",
-#)
+git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    tag = "0.9.0",
+)
 
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
 
+apple_rules_dependencies()
+
+git_repository(
+    name = "build_bazel_rules_swift",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+    tag = "0.4.0",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+git_repository(
+    name = "bazel_skylib",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
+    tag = "0.6.0",
+)
 
 git_repository(
     name = "com_github_bazelbuild_buildtools",
     remote = "https://github.com/bazelbuild/buildtools.git",
     tag = "0.11.1",
-)
-
-git_repository(
-    name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.5.0",
-)
-
-git_repository(
-    name = "bazel_skylib",
-    remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.4.0",
 )
 
 http_file(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,18 +47,6 @@ git_repository(
 )
 
 git_repository(
-    name = "com_github_bazelbuild_buildtools",
-    remote = "https://github.com/bazelbuild/buildtools.git",
-    tag = "0.11.1",
-)
-
-http_file(
-    name = "xctestrunner",
-    executable = 1,
-    url = "https://github.com/google/xctestrunner/releases/download/0.2.3/ios_test_runner.par",
-)
-
-git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
     tag = "v2.0.0",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 git_repository(
     name = "build_bazel_rules_apple",
@@ -50,4 +51,10 @@ git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
     tag = "v2.0.0",
+)
+
+http_file(
+    name = "xctestrunner",
+    executable = 1,
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.5/ios_test_runner.par"],
 )


### PR DESCRIPTION
This increases the following versions:

- bazel from 0.11 to 0.20.0
- build_bazel_rules_apple from 0.5.0 to 0.9.0
- build_bazel_rules_swift to 0.4.0 (new)
- bazel_skylib from 0.4.0 to 0.6.0

Tested by running:

    bazel build //...

This change removes the need for header rewrites because we now rely on bazel to handle framework style imports correctly.