### PR TITLE
Add workspace_root to framework import path.

### DIFF
--- a/apple_framework_relative_headers.bzl
+++ b/apple_framework_relative_headers.bzl
@@ -15,7 +15,7 @@ def _apple_framework_relative_headers_impl(ctx):
     outputs.append(framework_header_file)
 
   include_dir = "/".join([
-      ctx.configuration.bin_dir.path, ctx.label.package, output_dir])
+      ctx.configuration.bin_dir.path, ctx.label.workspace_root, ctx.label.package, output_dir])
   return [
       apple_common.new_objc_provider(
           header=depset(outputs),

--- a/apple_framework_relative_headers.bzl
+++ b/apple_framework_relative_headers.bzl
@@ -14,6 +14,10 @@ def _apple_framework_relative_headers_impl(ctx):
     file_actions.symlink(ctx, f, framework_header_file)
     outputs.append(framework_header_file)
 
+  # Documentation of these implicit types can be found here:
+  # ctx: https://docs.bazel.build/versions/master/skylark/lib/ctx.html
+  # ctx.label: https://docs.bazel.build/versions/master/skylark/lib/Label.html
+
   include_dir = "/".join([
       ctx.configuration.bin_dir.path, ctx.label.workspace_root, ctx.label.package, output_dir])
   return [


### PR DESCRIPTION
This fixes bazel build failures due to missing header imports when this library is used as a dependency in another bazel workspace and its headers are imported using framework-style imports.

This unblocks https://github.com/material-components/material-components-ios/pull/5926.