### PR TITLE
[clang-format-ci] Recursively initialize submodules

### DIFF
--- a/.clang-format-ci
+++ b/.clang-format-ci
@@ -48,6 +48,7 @@ lint_clang_format() {
   git fetch > /dev/null
   TAG=$(git tag --sort=v:refname -l "$CLANG_FORMAT_CI_VERSION" | tail -n1)
   git checkout "$TAG" > /dev/null
+  git submodule update --init --recursive
   echo "Using clang-format-ci $TAG"
   popd
 


### PR DESCRIPTION
This is related to https://github.com/material-components/material-components-ios/pull/6471.

This is a protective change in case future releases change the submodules they need to initialize.