### PR TITLE
Upgrade bazel to 1.1.0

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -34,7 +34,11 @@ popd
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
-  use_bazel.sh 0.20.0
+  if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh" ]; then
+    bash "$KOKORO_GFILE_DIR/use_bazel.sh" 1.1.0
+  else
+    use_bazel.sh 1.1.0
+  fi
   bazel version
 fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -34,11 +34,7 @@ popd
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
-  if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh" ]; then
-    bash "$KOKORO_GFILE_DIR/use_bazel.sh" 1.1.0
-  else
-    use_bazel.sh 1.1.0
-  fi
+  use_bazel.sh 1.1.0
   bazel version
 fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -38,6 +38,6 @@ if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
 fi
 
-./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
+./.kokoro-ios-runner/bazel.sh test //:UnitTests --min-xcode-version 9.0
 
 echo "Success!"

--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -49,6 +50,13 @@ apple_framework_relative_headers(
         "Sources/*.h",
     ]),
     framework_name = "MDFInternationalization",
+)
+
+build_test(
+    name = "BuildTest",
+    targets = [
+        ":MDFInternationalization"
+    ],
 )
 
 objc_library(

--- a/BUILD
+++ b/BUILD
@@ -67,7 +67,7 @@ ios_unit_test(
     deps = [
       ":UnitTestsLib",
     ],
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     timeout = "short",
     visibility = ["//visibility:private"],
 )

--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 load(":apple_framework_relative_headers.bzl", "apple_framework_relative_headers")
@@ -62,12 +63,30 @@ objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_test_runner(
+    name = "IPAD_PRO_12_9_IN_9_3",
+    device_type = "iPad Pro (12.9-inch)",
+    os_version = "9.3",
+    visibility = ["//visibility:public"],
+)
+
+ios_test_runner(
+    name = "IPHONE_7_PLUS_IN_10_3",
+    device_type = "iPhone 7 Plus",
+    os_version = "10.3",
+    visibility = ["//visibility:public"],
+)
+
+ios_unit_test_suite(
     name = "UnitTests",
     deps = [
       ":UnitTestsLib",
     ],
     minimum_os_version = "9.0",
     timeout = "short",
+    runners = [
+        ":IPAD_PRO_12_9_IN_9_3",
+        ":IPHONE_7_PLUS_IN_10_3",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/BUILD
+++ b/BUILD
@@ -95,7 +95,7 @@ ios_test_runner(
 ios_test_runner(
     name = "IPHONE_XS_MAX_IN_12_4",
     device_type = "iPhone Xs Max",
-    os_version = "12.4",
+    os_version = "12.2",
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -94,7 +94,7 @@ ios_test_runner(
 
 ios_test_runner(
     name = "IPHONE_XS_MAX_IN_12_4",
-    device_type = "iPhone XS Max",
+    device_type = "iPhone Xs Max",
     os_version = "12.4",
     visibility = ["//visibility:public"],
 )

--- a/BUILD
+++ b/BUILD
@@ -85,6 +85,20 @@ ios_test_runner(
     visibility = ["//visibility:public"],
 )
 
+ios_test_runner(
+    name = "IPHONE_X_IN_11_4",
+    device_type = "iPhone X",
+    os_version = "11.4",
+    visibility = ["//visibility:public"],
+)
+
+ios_test_runner(
+    name = "IPHONE_XS_MAX_IN_12_4",
+    device_type = "iPhone XS Max",
+    os_version = "12.4",
+    visibility = ["//visibility:public"],
+)
+
 ios_unit_test_suite(
     name = "UnitTests",
     deps = [
@@ -95,6 +109,8 @@ ios_unit_test_suite(
     runners = [
         ":IPAD_PRO_12_9_IN_9_3",
         ":IPHONE_7_PLUS_IN_10_3",
+        ":IPHONE_X_IN_11_4",
+        ":IPHONE_XS_MAX_IN_12_4",
     ],
     visibility = ["//visibility:private"],
 )

--- a/MDFInternationalization.podspec
+++ b/MDFInternationalization.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/material-foundation/material-internationalization-ios"
   s.license      = "Apache License, Version 2.0"
   s.source       = { :git => "https://github.com/material-foundation/material-internationalization-ios.git", :tag => "v#{s.version}" }
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "9.0"
 
   s.requires_arc = true
   s.public_header_files = "Sources/*.h"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.9.0",
+    commit = "19f031f09185e0fcd722c22e596d09bd6fff7944",  # 0.19.0
+    shallow_since = "1570721035 -0700",
 )
 
 load(
@@ -28,12 +29,6 @@ load(
 
 apple_rules_dependencies()
 
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.4.0",
-)
-
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
@@ -41,20 +36,16 @@ load(
 
 swift_rules_dependencies()
 
-git_repository(
-    name = "bazel_skylib",
-    remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.6.0",
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
 )
+
+apple_support_dependencies()
 
 git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
-    tag = "v2.0.0",
-)
-
-http_file(
-    name = "xctestrunner",
-    executable = 1,
-    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.5/ios_test_runner.par"],
+    commit = "c3f720c0838af1ee53299aa6efda87cf729146b4",  # v3.0.0
+    shallow_since = "1545400728 -0500"
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
     commit = "19f031f09185e0fcd722c22e596d09bd6fff7944",  # 0.19.0
-    shallow_since = "1570721035 -0700",
+    shallow_since = "10-10-2019",
 )
 
 load(
@@ -47,5 +47,5 @@ git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
     commit = "c3f720c0838af1ee53299aa6efda87cf729146b4",  # v3.0.0
-    shallow_since = "1545400728 -0500"
+    shallow_since = "12-21-2018",
 )

--- a/apple_framework_relative_headers.bzl
+++ b/apple_framework_relative_headers.bzl
@@ -1,7 +1,9 @@
 """Bazel rules for supporting framework-relative header imports."""
 
-load("@build_bazel_rules_apple//apple/bundling:file_actions.bzl", "file_actions")
-
+load(
+    "@build_bazel_rules_apple//apple/internal:file_support.bzl",
+    "file_support",
+)
 
 def _apple_framework_relative_headers_impl(ctx):
   """Implementation for apple_framework_relative_headers rule."""
@@ -11,7 +13,7 @@ def _apple_framework_relative_headers_impl(ctx):
   for f in ctx.files.hdrs:
     framework_path =  "/".join([output_dir, ctx.attr.framework_name, f.basename])
     framework_header_file = ctx.actions.declare_file(framework_path)
-    file_actions.symlink(ctx, f, framework_header_file)
+    file_support.symlink(ctx, f, framework_header_file)
     outputs.append(framework_header_file)
 
   # Documentation of these implicit types can be found here:
@@ -36,8 +38,7 @@ apple_framework_relative_headers = rule(
         "framework_name": attr.string(mandatory=True),
         "_realpath": attr.label(
             cfg="host",
-            allow_files=True,
-            single_file=True,
+            allow_single_file=True,
             default=Label("@bazel_tools//tools/objc:realpath"),
         ),
     },


### PR DESCRIPTION
Upgrades the WORKSPACE dependencies and the kokoro script accordingly.

Closes https://github.com/material-foundation/material-internationalization-ios/issues/57