### PR TITLE
Minor cleanup after https://github.com/material-foundation/material-internationalization-ios/pull/55

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -68,35 +68,30 @@ objc_library(
         ":MDFInternationalization",
         ":MDFInternationalizationFrameworkHeaders",
     ],
-    visibility = ["//visibility:private"],
 )
 
 ios_test_runner(
     name = "IPAD_PRO_12_9_IN_9_3",
     device_type = "iPad Pro (12.9-inch)",
     os_version = "9.3",
-    visibility = ["//visibility:public"],
 )
 
 ios_test_runner(
     name = "IPHONE_7_PLUS_IN_10_3",
     device_type = "iPhone 7 Plus",
     os_version = "10.3",
-    visibility = ["//visibility:public"],
 )
 
 ios_test_runner(
     name = "IPHONE_X_IN_11_4",
     device_type = "iPhone X",
     os_version = "11.4",
-    visibility = ["//visibility:public"],
 )
 
 ios_test_runner(
-    name = "IPHONE_XS_MAX_IN_12_4",
+    name = "IPHONE_XS_MAX_IN_12_2",
     device_type = "iPhone Xs Max",
     os_version = "12.2",
-    visibility = ["//visibility:public"],
 )
 
 ios_unit_test_suite(
@@ -110,7 +105,6 @@ ios_unit_test_suite(
         ":IPAD_PRO_12_9_IN_9_3",
         ":IPHONE_7_PLUS_IN_10_3",
         ":IPHONE_X_IN_11_4",
-        ":IPHONE_XS_MAX_IN_12_4",
+        ":IPHONE_XS_MAX_IN_12_2",
     ],
-    visibility = ["//visibility:private"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
     commit = "19f031f09185e0fcd722c22e596d09bd6fff7944",  # 0.19.0
-    shallow_since = "10-10-2019",
+    shallow_since = "1570721035 -0700",  # 10-10-2019
 )
 
 load(
@@ -47,5 +47,5 @@ git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
     commit = "c3f720c0838af1ee53299aa6efda87cf729146b4",  # v3.0.0
-    shallow_since = "12-21-2018",
+    shallow_since = "1545400728 -0500"  # 12-21-2018
 )


### PR DESCRIPTION
Most targets do not need public visibility; the ones that do not have been adjusted accordingly. Private visibility is the default, so I've removed the explicit private declarations.

A typo in the iPhone Xs Max simulator's ios_test_runner target has been fixed.

Follow-up to https://github.com/material-foundation/material-internationalization-ios/issues/57