### PR TITLE
Adding SPM Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .target(
             name: "MDFInternationalization",
             path: "Sources",
+            exclude: ["Info.plist"],
             publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "MDFInternationalization",
+    platforms: [
+        .iOS("9.0")
+    ],
+    products: [
+        .library(name: "MDFInternationalization", targets: ["MDFInternationalization"])
+    ],
+    targets: [
+        .target(
+            name: "MDFInternationalization",
+            path: "Sources",
+            publicHeadersPath: ".")
+    ]
+)

--- a/Sources/MDFInternationalization.h
+++ b/Sources/MDFInternationalization.h
@@ -16,11 +16,11 @@
 
 #import <UIKit/UIKit.h>
 
-#import <MDFInternationalization/MDFRTL.h>
-#import <MDFInternationalization/NSLocale+MaterialRTL.h>
-#import <MDFInternationalization/NSString+MaterialBidi.h>
-#import <MDFInternationalization/UIImage+MaterialRTL.h>
-#import <MDFInternationalization/UIView+MaterialRTL.h>
+#import "MDFRTL.h"
+#import "NSLocale+MaterialRTL.h"
+#import "NSString+MaterialBidi.h"
+#import "UIImage+MaterialRTL.h"
+#import "UIView+MaterialRTL.h"
 
 //! Project version number for MDFInternationalization.
 FOUNDATION_EXPORT double MDFInternationalizationVersionNumber;

--- a/Sources/module.modulemap
+++ b/Sources/module.modulemap
@@ -1,4 +1,0 @@
-module MDFInternationalization {
-  requires objc, objc_arc
-  header "MDFInternationalization.h"
-}

--- a/Sources/module.modulemap
+++ b/Sources/module.modulemap
@@ -1,4 +1,4 @@
-module MDFTextAccessibility {
+module MDFInternationalization {
   requires objc, objc_arc
   header "MDFInternationalization.h"
 }

--- a/Sources/module.modulemap
+++ b/Sources/module.modulemap
@@ -1,0 +1,4 @@
+module MDFTextAccessibility {
+  requires objc, objc_arc
+  header "MDFInternationalization.h"
+}


### PR DESCRIPTION
- Added SPM support.
- The changes in `MDFInternationalization.h` were required otherwise SPM couldn't find the headers. I tested these changes using Cocoapods and everything still seems to work.
- Module map was needed to expose the headers to Swift.